### PR TITLE
fix link to server endpoint docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ lollms-server --host 0.0.0.0 --port 5000
 - `add_personality`: Add a new personality to the server.
 - `generate_text`: Generate text based on the provided prompt and selected personality.
 
-For more details refer to the [API documentation](doc/server_endpoints.md)
+For more details refer to the [API documentation](docs/server_endpoints.md)
 
 ### RESTful API
 


### PR DESCRIPTION
The link is missing a "s" in "docs"

The link to the `server_endpoints` markdown is broken. This fix adds a missing s in `docs` to fix the broken link.