### PR TITLE
Changed sockeio to sio

### DIFF
--- a/lollms/server/elf.py
+++ b/lollms/server/elf.py
@@ -41,7 +41,7 @@ def main():
     if args.port:
         config.port=args.port
 
-    LOLLMSElfServer.build_instance(config=config, lollms_paths=lollms_paths, socketio=sio)
+    LOLLMSElfServer.build_instance(config=config, lollms_paths=lollms_paths, sio=sio)
     from lollms.server.endpoints.lollms_files_server import router as lollms_binding_files_server_router
     from lollms.server.endpoints.lollms_infos import router as lollms_infos_router
     from lollms.server.endpoints.lollms_hardware_infos import router as lollms_hardware_infos_router

--- a/lollms/server/elf_server.py
+++ b/lollms/server/elf_server.py
@@ -56,6 +56,8 @@ class LOLLMSElfServer(LollmsApplication):
         lollms_paths: LollmsPaths,
         load_binding=True,
         load_model=True,
+        load_voice_service=True,  
+        load_sd_service=True, 
         try_select_binding=False,
         try_select_model=False,
         callback=None,


### PR DESCRIPTION
LOLLMSElfServer.build_instance() expects a param named sio (type AsyncServer), but you called it with socketio in elf.py. That mismatch triggers:

TypeError: LOLLMSElfServer.build_instance() got an unexpected keyword argument 'socketio'
Which was causing error

![sioError](https://github.com/user-attachments/assets/8d003ac8-5745-4e07-b534-a108856a2a3d)
